### PR TITLE
Add hash support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,5 +21,5 @@ pygments_style = 'sphinx'
 intersphinx_mapping = {'tornado': ('http://www.tornadoweb.org/en/stable/', None),
                        'python': ('https://docs.python.org/3/', None)}
 
-html_static_path = ['_static']
+html_static_path = []
 #autodoc_member_order = 'bysource'

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+- Next Version
+
+  - Add `Hash commands <http://redis.io/commands#hash>`_
+
 - 0.3.0 - released *2016-01-18*
 
   - Remove broken pipelining implementation

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
+#
+
 import setuptools
 
-classifiers = ['Development Status :: 3 - Alpha',
+classifiers = ['Development Status :: 5 - Production/Stable',
                'Intended Audience :: Developers',
                'License :: OSI Approved :: BSD License',
                'Operating System :: OS Independent',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,25 @@
+import os
+import logging
+
+
+try:
+    with open('build/env-vars') as env_file:
+        for line_num, line in enumerate(env_file):
+            if line.startswith('export '):
+                line = line[7:].strip()
+            name, sep, value = line.partition('=')
+            name, value = name.strip(), value.strip()
+            if sep != '=':
+                logging.warning('ignoring line %d in environment file - %s',
+                                line_num, line)
+                continue
+
+            if value:
+                logging.info('setting environment variable %s = %r',
+                             name, value)
+                os.environ[name] = value
+            else:
+                logging.info('clearing environment variable %s', name)
+                os.environ.pop('name', None)
+except IOError:
+    logging.info('expected environment file at build/env-vars')

--- a/tests/hash_tests.py
+++ b/tests/hash_tests.py
@@ -1,0 +1,225 @@
+from tornado import testing
+
+from . import base
+
+
+class HashTests(base.AsyncTestCase):
+
+    @testing.gen_test
+    def test_hset(self):
+        key, field, value = self.uuid4(3)
+        result = yield self.client.hset(key, field, value)
+        self.assertEqual(result, 1)
+
+    @testing.gen_test
+    def test_hset_return_value_for_overwrite(self):
+        key, field, init_value, new_value = self.uuid4(4)
+        result = yield self.client.hset(key, field, init_value)
+        self.assertEqual(result, 1)
+
+        result = yield self.client.hset(key, field, new_value)
+        self.assertEqual(result, 0)
+
+    @testing.gen_test
+    def test_hget(self):
+        key, field, value = self.uuid4(3)
+        result = yield self.client.hset(key, field, value)
+        self.assertEqual(result, 1)
+        result = yield self.client.hget(key, field)
+        self.assertEqual(result, value)
+
+    @testing.gen_test
+    def test_hset_overwrites(self):
+        key, field, init_value, new_value = self.uuid4(4)
+        yield self.client.hset(key, field, init_value)
+        yield self.client.hset(key, field, new_value)
+        value = yield self.client.hget(key, field)
+        self.assertEqual(value, new_value)
+
+    @testing.gen_test
+    def test_hgetall_returns_dict(self):
+        key = self.uuid4()
+        field1, value1 = self.uuid4(2)
+        yield self.client.hset(key, field1, value1)
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result, {field1: value1})
+
+        field2, value2 = self.uuid4(2)
+        yield self.client.hset(key, field2, value2)
+
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result, {field1: value1, field2: value2})
+
+    @testing.gen_test
+    def test_hgetall_on_non_hash(self):
+        key = self.uuid4()
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result, {})
+
+    @testing.gen_test
+    def test_hmset(self):
+        key = self.uuid4()
+        field1, value1 = self.uuid4(2)
+        field2, value2 = self.uuid4(2)
+        field3, value3 = self.uuid4(2)
+        result = yield self.client.hmset(
+            key, {field1: value1, field2: value2, field3: value3})
+        self.assertTrue(result)
+
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result,
+                         {field1: value1, field2: value2, field3: value3})
+
+    @testing.gen_test
+    def test_hmset_of_empty_dict(self):
+        key = self.uuid4()
+        result = yield self.client.hmset(key, {})
+        self.assertFalse(result)
+
+    @testing.gen_test
+    def test_hmget(self):
+        key = self.uuid4()
+        field1, value1 = self.uuid4(2)
+        field2, value2 = self.uuid4(2)
+        field3, value3 = self.uuid4(2)
+        yield self.client.hmset(
+            key, {field1: value1, field2: value2, field3: value3})
+
+        result = yield self.client.hmget(key, field1, field3)
+        self.assertEqual(result, {field1: value1, field3: value3})
+
+    @testing.gen_test
+    def test_that_hmget_returns_none_values_for_nonexistent_key(self):
+        key = self.uuid4()
+        result = yield self.client.hmget(key, 'one', 'two', 'three')
+        self.assertEqual(result, {'one': None, 'two': None, 'three': None})
+
+    @testing.gen_test
+    def test_hdel(self):
+        key = self.uuid4()
+        field1, value1 = self.uuid4(2)
+        field2, value2 = self.uuid4(2)
+        field3, value3 = self.uuid4(2)
+        yield self.client.hmset(
+            key, {field1: value1, field2: value2, field3: value3})
+
+        result = yield self.client.hdel(key, field1)
+        self.assertEqual(result, 1)
+
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result, {field2: value2, field3: value3})
+
+        result = yield self.client.hdel(key, field2, field3)
+        self.assertEqual(result, 2)
+
+        result = yield self.client.hgetall(key)
+        self.assertEqual(result, {})
+
+        result = yield self.client.hdel(key, 'nofield')
+        self.assertEqual(result, 0)
+
+        result = yield self.client.hdel(self.uuid4(), 'nofield')
+        self.assertEqual(result, 0)
+
+    @testing.gen_test
+    def test_hdel_without_fields_returns_zero(self):
+        result = yield self.client.hdel(self.uuid4())
+        self.assertEqual(result, 0)
+
+    @testing.gen_test
+    def test_hexist(self):
+        key = self.uuid4()
+        result = yield self.client.hexists(key, 'nofield')
+        self.assertFalse(result)
+
+        yield self.client.hset(key, 'field', self.uuid4())
+        result = yield self.client.hexists(key, 'field')
+        self.assertTrue(result)
+
+        result = yield self.client.hexists(key, 'nofield')
+        self.assertFalse(result)
+
+    @testing.gen_test
+    def test_hincrby(self):
+        key, field = self.uuid4(2)
+
+        result = yield self.client.hincrby(key, field, 1)
+        self.assertEqual(result, 1)
+
+        result = yield self.client.hget(key, field)
+        self.assertEqual(result, b'1')
+
+        result = yield self.client.hincrby(key, field, 0x7fffFFFFffffFFFE)
+        self.assertEqual(result, 0x7fffFFFFffffFFFF)
+
+        result = yield self.client.hincrby(key, field, -0x7fffFFFFffffFFFF)
+        self.assertEqual(result, 0)
+
+    @testing.gen_test
+    def test_hincrbyfloat(self):
+        key, field = self.uuid4(2)
+
+        result = yield self.client.hincrbyfloat(key, field, 10.5)
+        self.assertAlmostEqual(result, 10.500000)
+
+        result = yield self.client.hincrbyfloat(key, field, 0.1)
+        self.assertAlmostEqual(result, 10.600000)
+
+        result = yield self.client.hincrbyfloat(key, field, -5)
+        self.assertAlmostEqual(result, 5.600000)
+
+        result = yield self.client.hincrbyfloat(key, field, 2.0e2)
+        self.assertAlmostEqual(result, 205.600000)
+
+    @testing.gen_test
+    def test_hkeys(self):
+        key, field1, field2, field3 = self.uuid4(4)
+
+        result = yield self.client.hkeys(key)
+        self.assertEqual(result, [])
+
+        yield self.client.hmset(key, {field1: self.uuid4(),
+                                      field2: self.uuid4(),
+                                      field3: self.uuid4()})
+        result = yield self.client.hkeys(key)
+        self.assertEqual(sorted(result), sorted([field1, field2, field3]))
+
+    @testing.gen_test
+    def test_hlen(self):
+        key = self.uuid4()
+
+        result = yield self.client.hlen(key)
+        self.assertEqual(result, 0)
+
+        yield self.client.hmset(key, {'a': 1, 'b': 2, 'c': 3})
+        result = yield self.client.hlen(key)
+        self.assertEqual(result, 3)
+
+    @testing.gen_test
+    def test_hsetnx(self):
+        key, field, value = self.uuid4(3)
+
+        result = yield self.client.hsetnx(key, field, value)
+        self.assertEqual(result, 1)
+
+        result = yield self.client.hget(key, field)
+        self.assertEqual(result, value)
+
+        result = yield self.client.hsetnx(key, field, self.uuid4())
+        self.assertEqual(result, 0)
+
+        result = yield self.client.hget(key, field)
+        self.assertEqual(result, value)
+
+    @testing.gen_test
+    def test_hvals(self):
+        key = self.uuid4()
+        result = yield self.client.hvals(key)
+        self.assertEqual(result, [])
+
+        yield self.client.hmset(key,
+                                {'f1': 'HelloWorld', 'f2': 99, 'f3': -256})
+
+        result = yield self.client.hvals(key)
+        self.assertEqual(sorted(result),
+                         sorted([b'HelloWorld', b'99', b'-256']))

--- a/tests/keys_tests.py
+++ b/tests/keys_tests.py
@@ -147,12 +147,12 @@ class KeyCommandTests(base.AsyncTestCase):
     @testing.gen_test
     def test_keys(self):
         yield self.client.select(3)
-        prefix = 'keys-test'
+        prefix = self.uuid4()
         keys = ['{}-{}'.format(prefix, str(uuid.uuid4())).encode('ascii')
                 for i in range(0, 10)]
         for key in keys:
             yield self.expiring_set(key, str(uuid.uuid4()))
-        result = yield self.client.keys('{}*'.format(prefix))
+        result = yield self.client.keys('{}-*'.format(prefix))
         self.assertListEqual(sorted(result), sorted(keys))
 
     @testing.gen_test
@@ -258,6 +258,9 @@ class KeyCommandTests(base.AsyncTestCase):
     @testing.gen_test
     def test_randomkey(self):
         yield self.client.select(4)
+        keys = yield self.client.keys('*')
+        self.client.delete(*keys)
+
         keys = self.uuid4(10)
         for key in list(keys):
             yield self.expiring_set(key, str(uuid.uuid4()))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py33,py34
+toxworkdir = build/tox
+
+[testenv]
+deps = -rtest-requirements.txt
+commands = nosetests

--- a/tredis/__init__.py
+++ b/tredis/__init__.py
@@ -138,6 +138,8 @@ class RedisClient(server.ServerMixin,
             return self._encode_resp(value.encode('utf-8'))
         elif isinstance(value, int):
             return self._encode_resp(ascii(value).encode('ascii'))
+        elif isinstance(value, float):
+            return self._encode_resp(ascii(value).encode('ascii'))
         elif isinstance(value, list):
             output = [b'*', ascii(len(value)).encode('ascii'), CRLF]
             for item in value:

--- a/tredis/hashes.py
+++ b/tredis/hashes.py
@@ -1,6 +1,303 @@
 """Redis Hash Commands Mixin"""
+from tornado import concurrent
 
 
 class HashesMixin(object):
     """Redis Hash Commands Mixin"""
-    pass
+
+    def hset(self, key, field, value):
+        """Sets `field` in the hash stored at `key` to `value`.
+
+        If `key` does not exist, a new key holding a hash is created. If
+        `field` already exists in the hash, it is overwritten.
+
+        .. note::
+
+           **Time complexity**: always ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: The field in the hash to set
+        :type key: :class:`str`, :class:`bytes`
+        :param value: The value to set the field to
+        :returns: ``1`` if `field` is a new field in the hash and `value`
+            was set; otherwise, ``0`` if `field` already exists in the hash
+            and the value was updated
+        :rtype: int
+
+        """
+        return self._execute([b'HSET', key, field, value])
+
+    def hget(self, key, field):
+        """
+        Returns the value associated with `field` in the hash stored at `key`.
+
+        .. note::
+
+           **Time complexity**: always ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: The field in the hash to get
+        :type key: :class:`str`, :class:`bytes`
+        :rtype: bytes, list
+        :raises: :exc:`~tredis.exceptions.RedisError`
+
+        """
+        return self._execute([b'HGET', key, field])
+
+    def hgetall(self, key):
+        """
+        Returns all fields and values of the has stored at `key`.
+
+        The underlying redis `HGETALL`_ command returns an array of
+        pairs.  This method converts that to a Python :class:`dict`.
+        It will return an empty :class:`dict` when the key is not
+        found.
+
+        .. note::
+
+           **Time complexity**: ``O(N)`` where ``N`` is the size
+           of the hash.
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :returns: a :class:`dict` of key to value mappings for all
+            fields in the hash
+
+        .. _HGETALL: http://redis.io/commands/hgetall
+
+        """
+        def format_response(value):
+            return dict(zip(value[::2], value[1::2]))
+        return self._execute([b'HGETALL', key],
+                             format_callback=format_response)
+
+    def hmset(self, key, value_dict):
+        """
+        Sets fields to values as in `value_dict` in the hash stored at `key`.
+
+        Sets the specified fields to their respective values in the hash
+        stored at `key`.  This command overwrites any specified fields
+        already existing in the hash.  If `key` does not exist, a new  key
+        holding a hash is created.
+
+        .. note::
+
+           **Time complexity**: ``O(N)`` where ``N`` is the number of
+           fields being set.
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param value_dict: field to value mapping
+        :type value_dict: :class:`dict`
+        :rtype: bool
+        :raises: :exc:`~tredis.exceptions.RedisError`
+
+        """
+        if not value_dict:
+            future = concurrent.TracebackFuture()
+            future.set_result(False)
+        else:
+            command = [b'HMSET', key]
+            command.extend(sum(value_dict.items(), ()))
+            future = self._execute(command)
+        return future
+
+    def hmget(self, key, *fields):
+        """
+        Returns the values associated with the specified `fields` in a hash.
+
+        For every ``field`` that does not exist in the hash, :data:`None`
+        is returned.  Because a non-existing keys are treated as empty
+        hashes, calling :meth:`hmget` against a non-existing key will
+        return a list of :data:`None` values.
+
+        .. note::
+
+           *Time complexity*: ``O(N)`` where ``N`` is the number of fields
+           being requested.
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param fields: iterable of field names to retrieve
+        :returns: a :class:`dict` of field name to value mappings for
+            each of the requested fields
+        :rtype: dict
+
+        """
+        def format_response(val_array):
+            return dict(zip(fields, val_array))
+
+        command = [b'HMGET', key]
+        command.extend(fields)
+        return self._execute(command, format_callback=format_response)
+
+    def hdel(self, key, *fields):
+        """
+        Remove the specified fields from the hash stored at `key`.
+
+        Specified fields that do not exist within this hash are ignored.
+        If `key` does not exist, it is treated as an empty hash and this
+        command returns zero.
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param fields: iterable of field names to retrieve
+        :returns: the number of fields that were removed from the hash,
+            not including specified by non-existing fields.
+        :rtype: int
+
+        """
+        if not fields:
+            future = concurrent.TracebackFuture()
+            future.set_result(0)
+        else:
+            future = self._execute([b'HDEL', key] + list(fields))
+        return future
+
+    def hexists(self, key, field):
+        """
+        Returns if `field` is an existing field in the hash stored at `key`.
+
+        .. note::
+
+           *Time complexity*: ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: name of the field to test for
+        :type key: :class:`str`, :class:`bytes`
+        :rtype: bool
+
+        """
+        return self._execute([b'HEXISTS', key, field])
+
+    def hincrby(self, key, field, increment):
+        """
+        Increments the number stored at `field` in the hash stored at `key`.
+
+        If `key` does not exist, a new key holding a hash is created.  If
+        `field` does not exist the value is set to ``0`` before the operation
+        is performed.  The range of values supported is limited to 64-bit
+        signed integers.
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: name of the field to increment
+        :type key: :class:`str`, :class:`bytes`
+        :param increment: amount to increment by
+        :type increment: int
+
+        :returns: the value at `field` after the increment occurs
+        :rtype: int
+
+        """
+        return self._execute([b'HINCRBY', key, field, increment],
+                             format_callback=int)
+
+    def hincrbyfloat(self, key, field, increment):
+        """
+        Increments the number stored at `field` in the hash stored at `key`.
+
+        If the increment value is negative, the result is to have the hash
+        field **decremented** instead of incremented.  If the field does not
+        exist, it is set to ``0`` before performing the operation.  An error
+        is returned if one of the following conditions occur:
+
+        - the field contains a value of the wrong type (not a string)
+        - the current field content or the specified increment are not
+          parseable as a double precision floating point number
+
+        .. note::
+
+           *Time complexity*: ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: name of the field to increment
+        :type key: :class:`str`, :class:`bytes`
+        :param increment: amount to increment by
+        :type increment: float
+
+        :returns: the value at `field` after the increment occurs
+        :rtype: float
+
+        """
+        return self._execute([b'HINCRBYFLOAT', key, field, increment],
+                             format_callback=float)
+
+    def hkeys(self, key):
+        """
+        Returns all field names in the hash stored at `key`.
+
+        .. note::
+
+           *Time complexity*: ``O(N)`` where ``N`` is the size of the hash
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :returns: the list of fields in the hash
+        :rtype: list
+
+        """
+        return self._execute([b'HKEYS', key])
+
+    def hlen(self, key):
+        """
+        Returns the number of fields contained in the hash stored at `key`.
+
+        .. note::
+
+           *Time complexity*: ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :returns: the number of fields in the hash or zero when `key`
+            does not exist
+        :rtype: int
+
+        """
+        return self._execute([b'HLEN', key])
+
+    def hsetnx(self, key, field, value):
+        """
+        Sets `field` in the hash stored at `key` only if it does not exist.
+
+        Sets `field` in the hash stored at `key` only if `field` does not
+        yet exist.  If `key` does not exist, a new key holding a hash is
+        created.  If `field` already exists, this operation has no effect.
+
+        .. note::
+
+           *Time complexity*: ``O(1)``
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :param field: The field in the hash to set
+        :type key: :class:`str`, :class:`bytes`
+        :param value: The value to set the field to
+        :returns: ``1`` if `field` is a new field in the hash and `value`
+            was set.  ``0`` if `field` already exists in the hash and
+            no operation was performed
+        :rtype: int
+
+        """
+        return self._execute([b'HSETNX', key, field, value])
+
+    def hvals(self, key):
+        """
+        Returns all values in the hash stored at `key`.
+
+        .. note::
+
+           *Time complexity* ``O(N)`` where ``N`` is the size of the hash
+
+        :param key: The key of the hash
+        :type key: :class:`str`, :class:`bytes`
+        :returns: a :class:`list` of :class:`bytes` instances or an
+            empty list when `key` does not exist
+        :rtype: list
+
+        """
+        return self._execute([b'HVALS', key])

--- a/tredis/hyperloglog.py
+++ b/tredis/hyperloglog.py
@@ -95,8 +95,10 @@ class HyperLogLogMixin(object):
 
         .. versionadded:: 0.2.0
 
-        .. note:: **Time complexity**: ``O(N)`` to merge ``N`` HyperLogLogs,
-        but with high constant times.
+        .. note::
+
+           **Time complexity**: ``O(N)`` to merge ``N`` HyperLogLogs, but
+           with high constant times.
 
         :param dest_key: The destination key
         :type dest_key: :class:`str`, :class:`bytes`

--- a/tredis/sortedsets.py
+++ b/tredis/sortedsets.py
@@ -4,7 +4,7 @@
 class SortedSetsMixin(object):
     """Redis Sorted Set Commands Mixin"""
 
-    def zadd(self, key, *members, xx=False, nx=False, ch=False, incr=False):
+    def zadd(self, key, *members, **kwargs):
         """Adds all the specified members with the specified scores to the
         sorted set stored at key. It is possible to specify multiple score /
         member pairs. If a specified member is already a member of the sorted
@@ -54,14 +54,18 @@ class SortedSetsMixin(object):
         :type key: :class:`str`, :class:`bytes`
         :param members: Elements to add
         :type members: :class:`dict`, :class:`str`, :class:`bytes`
-        :param bool xx: Only update elements that already exist
-        :param bool nx: Don't update already existing elements
-        :param bool ch: Return the number of changed elements
-        :param bool incr: Increment the score of an element
+        :keyword bool xx: Only update elements that already exist
+        :keyword bool nx: Don't update already existing elements
+        :keyword bool ch: Return the number of changed elements
+        :keyword bool incr: Increment the score of an element
         :rtype: int, :class:`str`, :class:`bytes`
         :returns: Number of elements changed, or the new score if incr is set
         :raises: :exc:`~tredis.exceptions.RedisError`
         """
+        xx = kwargs.pop('xx', False)
+        nx = kwargs.pop('nx', False)
+        ch = kwargs.pop('ch', False)
+        incr = kwargs.pop('incr', False)
         command = [b'ZADD', key]
         if xx:
             command += ['XX']

--- a/tredis/sortedsets.py
+++ b/tredis/sortedsets.py
@@ -47,8 +47,8 @@ class SortedSetsMixin(object):
 
         .. note::
 
-        **Time complexity**: ``O(log(N))`` for each item added, where ``N`` is
-        the number of elements in the sorted set.
+           **Time complexity**: ``O(log(N))`` for each item added, where ``N``
+           is the number of elements in the sorted set.
 
         :param key: The key of the sorted set
         :type key: :class:`str`, :class:`bytes`
@@ -61,6 +61,7 @@ class SortedSetsMixin(object):
         :rtype: int, :class:`str`, :class:`bytes`
         :returns: Number of elements changed, or the new score if incr is set
         :raises: :exc:`~tredis.exceptions.RedisError`
+
         """
         xx = kwargs.pop('xx', False)
         nx = kwargs.pop('nx', False)
@@ -112,8 +113,8 @@ class SortedSetsMixin(object):
         **Exclusive intervals and infinity**
 
         ``min_score`` and ``max_score`` can be ``-inf`` and ``+inf``, so that
-         you are not required to know the highest or lowest score in the sorted
-         set to get all elements from or up to a certain score.
+        you are not required to know the highest or lowest score in the sorted
+        set to get all elements from or up to a certain score.
 
         By default, the interval specified by ``min_score`` and ``max_score``
         is closed (inclusive). It is possible to specify an open interval
@@ -135,10 +136,10 @@ class SortedSetsMixin(object):
 
         .. note::
 
-        **Time complexity**: ``O(log(N)+M)`` with ``N`` being the number of
-        elements in the sorted set and ``M`` the number of elements being
-        returned. If ``M`` is constant (e.g. always asking for the first 10
-        elements with ``count``), you can consider it ``O(log(N))``.
+           **Time complexity**: ``O(log(N)+M)`` with ``N`` being the number of
+           elements in the sorted set and ``M`` the number of elements being
+           returned. If ``M`` is constant (e.g. always asking for the first
+           10 elements with ``count``), you can consider it ``O(log(N))``.
 
         :param key: The key of the sorted set
         :type key: :class:`str`, :class:`bytes`


### PR DESCRIPTION
This PR adds support for the redis [hash command set](http://redis.io/commands#hash) in what I think is a fairly Pythonic style.  The commands that use a list of keys and values in sequence (e.g., [HMSET](http://redis.io/commands/hmset)) use the more comfortable `dict`.